### PR TITLE
Add fi tupas and verimi as method to sign

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -157,6 +157,8 @@ const (
 	AuthenticationMethodToSignSEBankID AuthenticationMethodToSign = seBankID
 	AuthenticationMethodToSignNOBankID AuthenticationMethodToSign = noBankID
 	AuthenticationMethodToSignDKNemID  AuthenticationMethodToSign = dkNemID
+	AuthenticationMethodToSignFITupas  AuthenticationMethodToSign = fiTupas
+	AuthenticationMethodToSignVerimi   AuthenticationMethodToSign = verimi
 )
 
 func (s AuthenticationMethodToSign) strp() *string {


### PR DESCRIPTION
This adds the providers fi tupas and verimi as authentication method to
sign constants.

Thanks!