### PR TITLE
Rename verimi authentication to verimi_qes

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -23,6 +23,7 @@ const (
 	dkNemID         = "dk_nemid"
 	fiTupas         = "fi_tupas"
 	verimi          = "verimi"
+	verimiQes       = "verimi_qes"
 )
 
 type strDef interface {
@@ -158,7 +159,7 @@ const (
 	AuthenticationMethodToSignNOBankID AuthenticationMethodToSign = noBankID
 	AuthenticationMethodToSignDKNemID  AuthenticationMethodToSign = dkNemID
 	AuthenticationMethodToSignFITupas  AuthenticationMethodToSign = fiTupas
-	AuthenticationMethodToSignVerimi   AuthenticationMethodToSign = verimi
+	AuthenticationMethodToSignVerimi   AuthenticationMethodToSign = verimiQes
 )
 
 func (s AuthenticationMethodToSign) strp() *string {


### PR DESCRIPTION
According to Scrive, this should be the value (albeit not documented in their API).

Thanks!