### PR TITLE
fix: correct scrive_qes_global string, add itsme_qes

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -27,7 +27,8 @@ const (
 	verimi          = "verimi"
 	verimiQes       = "verimi_qes"
 	smartIDQes      = "smart_id_qes"
-	globalQes       = "global_qes"
+	globalQes       = "scrive_qes_global"
+	itsmeQes        = "itsme_qes"
 )
 
 type strDef interface {
@@ -183,6 +184,7 @@ const (
 	AuthenticationMethodToSignVerimi      AuthenticationMethodToSign = verimiQes
 	AuthenticationMethodToSignSmartID     AuthenticationMethodToSign = smartIDQes
 	AuthenticationMethodToSignGlobalQES   AuthenticationMethodToSign = globalQes
+	AuthenticationMethodToSignItsmeQES    AuthenticationMethodToSign = itsmeQes
 )
 
 func (s AuthenticationMethodToSign) strp() *string {


### PR DESCRIPTION
## Summary

- Fixes `global_qes` → `scrive_qes_global` to match the actual Scrive API string (ref: https://apidocs.scrive.com/#authentication-to-sign-with-settings)
- Adds `itsme_qes` constant and `AuthenticationMethodToSignItsmeQES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)