### PR TITLE
fix(errors): surface real HTTP status and body when response isn't JSON

### DIFF
--- a/api.go
+++ b/api.go
@@ -146,7 +146,11 @@ func (c *Client) expect(code int, respBody []byte, expectedCode int, out interfa
 	if code != expectedCode {
 		se, err := c.parseResponseError(respBody)
 		if err != nil {
-			return localError(err)
+			// The response body wasn't a Scrive JSON error envelope. Surface
+			// the actual HTTP status code and the (truncated) body so callers
+			// can debug 401/404/etc. responses that come back as plain text
+			// or HTML — instead of just a JSON parse error with HttpCode -1.
+			return unparseableResponseError(code, respBody)
 		}
 		return se
 	}

--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,7 @@ package scrive
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -21,7 +22,12 @@ const (
 	ErrorTypeDocumentObjectVersionMismatch ErrorType = "document_object_version_mismatch"
 	ErrorTypeSignatoryStateError           ErrorType = "signatory_state_error"
 	ErrorTypeLocal                         ErrorType = "local_error"
+	ErrorTypeUnparseableResponse           ErrorType = "unparseable_response"
 )
+
+// maxUnparseableBodyLen caps how many bytes of a non-JSON response body get
+// embedded in the error message, to avoid dumping multi-megabyte HTML pages.
+const maxUnparseableBodyLen = 512
 
 type se struct {
 	ErrorType    *ErrorType `json:"error_type"`
@@ -56,6 +62,24 @@ func localError(err error) *ScriveError {
 		ErrorType:    ErrorTypeLocal,
 		ErrorMessage: err.Error(),
 		HttpCode:     -1,
+	}
+}
+
+// unparseableResponseError wraps a non-JSON response body together with the
+// real HTTP status code, so callers can debug 401/404/etc. responses that
+// come back as plain text or HTML without losing the status or the body.
+func unparseableResponseError(httpCode int, body []byte) *ScriveError {
+	msg := strings.TrimSpace(string(body))
+	if len(msg) > maxUnparseableBodyLen {
+		msg = msg[:maxUnparseableBodyLen] + "…"
+	}
+	if msg == "" {
+		msg = "(empty response body)"
+	}
+	return &ScriveError{
+		ErrorType:    ErrorTypeUnparseableResponse,
+		ErrorMessage: msg,
+		HttpCode:     httpCode,
 	}
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,26 +1,54 @@
-package scrive_test
+package scrive
 
-/*
-func TestParseResponseErrorOk(t *testing.T) {
-	errBody := []byte(`
-		{
-			"error_type": "resource_not_found",
-			"error_message": "The resource was not found",
-			"http_code": 404
+import (
+	"strings"
+	"testing"
+)
+
+func TestUnparseableResponseError(t *testing.T) {
+	t.Run("preserves the HTTP status code", func(t *testing.T) {
+		se := unparseableResponseError(401, []byte("No valid access credentials were provided."))
+		if se.HttpCode != 401 {
+			t.Fatalf("expected HttpCode 401, got %d", se.HttpCode)
 		}
-	`)
-	se, err := scrive.ParseResponseError(errBody)
-	assert.NotNil(t, se)
-	assert.Nil(t, err)
-	assert.Equal(t, se.ErrorType, "resource_not_found")
-	assert.Equal(t, se.ErrorMessage, "The resource was not found")
-	assert.Equal(t, se.HttpCode, 404)
-}
+	})
 
-func TestParseResponseErrorNotOk(t *testing.T) {
-	errBody := []byte(`{}`)
-	se, err := scrive.ParseResponseError(errBody)
-	assert.Nil(t, se)
-	assert.NotNil(t, err)
+	t.Run("includes the body in the error message", func(t *testing.T) {
+		se := unparseableResponseError(401, []byte("No valid access credentials were provided."))
+		if !strings.Contains(se.ErrorMessage, "No valid access credentials") {
+			t.Fatalf("expected body in ErrorMessage, got %q", se.ErrorMessage)
+		}
+	})
+
+	t.Run("uses the unparseable_response error type", func(t *testing.T) {
+		se := unparseableResponseError(404, []byte("Not Found"))
+		if se.ErrorType != ErrorTypeUnparseableResponse {
+			t.Fatalf("expected ErrorType %q, got %q", ErrorTypeUnparseableResponse, se.ErrorType)
+		}
+	})
+
+	t.Run("trims whitespace from the body", func(t *testing.T) {
+		se := unparseableResponseError(500, []byte("\n\n  Internal Server Error  \n"))
+		if se.ErrorMessage != "Internal Server Error" {
+			t.Fatalf("expected trimmed body, got %q", se.ErrorMessage)
+		}
+	})
+
+	t.Run("truncates long bodies", func(t *testing.T) {
+		body := strings.Repeat("x", maxUnparseableBodyLen+100)
+		se := unparseableResponseError(500, []byte(body))
+		if !strings.HasSuffix(se.ErrorMessage, "…") {
+			t.Fatalf("expected truncated body to end with ellipsis, got %q", se.ErrorMessage)
+		}
+		if len(se.ErrorMessage) > maxUnparseableBodyLen+10 {
+			t.Fatalf("expected truncated message length around %d, got %d", maxUnparseableBodyLen, len(se.ErrorMessage))
+		}
+	})
+
+	t.Run("falls back to a placeholder for empty bodies", func(t *testing.T) {
+		se := unparseableResponseError(502, nil)
+		if !strings.Contains(se.ErrorMessage, "empty response body") {
+			t.Fatalf("expected placeholder for empty body, got %q", se.ErrorMessage)
+		}
+	})
 }
-*/


### PR DESCRIPTION
## Summary
When Scrive returns a non-success status with a non-JSON body (e.g. \`401 No valid access credentials were provided.\` as plain text), the previous error path called \`parseResponseError\` → fails to unmarshal → returns \`localError\` with \`HttpCode: -1\` and \`ErrorMessage: \"invalid character 'N' looking for beginning of value\"\`. The actual HTTP status and body were dropped, making 401/404/502 responses very hard to debug.

This PR adds \`unparseableResponseError(httpCode, body)\` that builds a \`ScriveError\` carrying the real HTTP status, \`ErrorType: ErrorTypeUnparseableResponse\`, and the body (trimmed + truncated to 512 bytes). The \`expect()\` error path now uses this fallback when \`parseResponseError\` fails.

**Before:**
\`\`\`
-1 local_error invalid character 'N' looking for beginning of value
\`\`\`

**After:**
\`\`\`
401 unparseable_response No valid access credentials were provided.
\`\`\`

## Test plan
- [x] \`go test -run TestUnparseableResponseError ./...\` (new unit tests cover: status preserved, body included, error type, whitespace trim, long-body truncation, empty-body placeholder)
- [x] \`go vet ./...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)