### PR TITLE
test(errors): cover Client.expect's four code paths end-to-end

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: go vet
+        run: go vet ./...
+      - name: go build
+        run: go build ./...
+      - name: go test
+        # Integration tests that hit the real Scrive API self-skip when
+        # CLIENT_CREDENTIALS_IDENTIFIER / TOKEN_CREDENTIALS_IDENTIFIER are
+        # unset (see common_test.go::hasScriveCredentials), so this runs
+        # the unit tests on every PR without needing credentials.
+        run: go test -race -count=1 ./...

--- a/api.go
+++ b/api.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 	"time"
 )
 
@@ -16,8 +17,16 @@ const (
 )
 
 type Config struct {
+	// APIRoot is either a bare hostname ("api-scrive.com" — implicitly
+	// https://) or a full base URL with scheme ("http://localhost:8080",
+	// useful for tests against an httptest server).
 	APIRoot *string
 	PAC     *PAC
+	// HTTPClient overrides the default *http.Client used for outgoing
+	// requests. Useful for plugging in httptest.NewServer().Client() or
+	// a transport with custom retries/timeouts. When nil, a default
+	// client with sensible production timeouts is used.
+	HTTPClient *http.Client
 }
 
 type Client struct {
@@ -39,10 +48,14 @@ func NewClient(c Config) (*Client, error) {
 	} else {
 		client.config.APIRoot = c.APIRoot
 	}
+	client.config.HTTPClient = c.HTTPClient
 	return client, nil
 }
 
 func (c *Client) httpClient() *http.Client {
+	if c.config.HTTPClient != nil {
+		return c.config.HTTPClient
+	}
 	return &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
@@ -55,7 +68,14 @@ func (c *Client) httpClient() *http.Client {
 }
 
 func (c *Client) composeURL(path string) string {
-	return fmt.Sprintf("https://%s/api/v2/%s", *c.config.APIRoot, path)
+	root := *c.config.APIRoot
+	// Allow APIRoot to include a scheme (e.g. "http://localhost:1234" for
+	// tests). Bare hostnames keep the historical https:// default so
+	// existing callers don't need to change.
+	if strings.Contains(root, "://") {
+		return fmt.Sprintf("%s/api/v2/%s", strings.TrimRight(root, "/"), path)
+	}
+	return fmt.Sprintf("https://%s/api/v2/%s", root, path)
 }
 
 func printDump(d []byte, err error) {

--- a/client_http_test.go
+++ b/client_http_test.go
@@ -1,0 +1,271 @@
+package scrive
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// stubScrive returns a *Client wired to a httptest.Server whose handler is
+// supplied by the test. The handler can record incoming requests and respond
+// with whatever body/status the test wants to assert against.
+func stubScrive(t *testing.T, handler http.HandlerFunc) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	root := srv.URL
+	cli, err := NewClient(Config{
+		APIRoot: &root,
+		PAC: &PAC{
+			ClientCredentialsIdentifier: "cci",
+			ClientCredentialsSecret:     "ccs",
+			TokenCredentialsIdentifier:  "tci",
+			TokenCredentialsSecret:      "tcs",
+		},
+		HTTPClient: srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return cli, srv
+}
+
+// recordedRequest is what the stub captures from each incoming request so the
+// test can assert on it without re-reading the body.
+type recordedRequest struct {
+	Method      string
+	Path        string
+	Auth        string
+	ContentType string
+	Body        []byte
+}
+
+func recordingHandler(captured *[]recordedRequest, mu *sync.Mutex, respond func(w http.ResponseWriter, r *http.Request, body []byte)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		*captured = append(*captured, recordedRequest{
+			Method:      r.Method,
+			Path:        r.URL.Path,
+			Auth:        r.Header.Get("Authorization"),
+			ContentType: r.Header.Get("Content-Type"),
+			Body:        body,
+		})
+		mu.Unlock()
+		respond(w, r, body)
+	}
+}
+
+func TestClient_NewDocument_Success(t *testing.T) {
+	var (
+		captured []recordedRequest
+		mu       sync.Mutex
+	)
+	cli, _ := stubScrive(t, recordingHandler(&captured, &mu, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"doc-123","status":"preparation"}`))
+	}))
+
+	doc, se := cli.NewDocument(NewDocumentParams{
+		FileName: "contract.pdf",
+		File:     []byte("%PDF-fake"),
+	})
+	if se != nil {
+		t.Fatalf("expected nil ScriveError, got %+v", se)
+	}
+	if doc.ID == nil || *doc.ID != "doc-123" {
+		t.Fatalf("expected ID doc-123, got %v", doc.ID)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(captured))
+	}
+	got := captured[0]
+	if got.Method != http.MethodPost {
+		t.Errorf("expected POST, got %s", got.Method)
+	}
+	if got.Path != "/api/v2/documents/new" {
+		t.Errorf("expected path /api/v2/documents/new, got %s", got.Path)
+	}
+	if !strings.HasPrefix(got.ContentType, "multipart/form-data") {
+		t.Errorf("expected multipart Content-Type, got %s", got.ContentType)
+	}
+	if !strings.Contains(string(got.Body), "contract.pdf") {
+		t.Errorf("expected file name in multipart body, got %s", got.Body)
+	}
+	if !strings.Contains(string(got.Body), "%PDF-fake") {
+		t.Errorf("expected file bytes in multipart body, got %s", got.Body)
+	}
+	if got.Auth == "" {
+		t.Errorf("expected Authorization header to be set")
+	}
+}
+
+func TestClient_NewDocument_NonSuccess(t *testing.T) {
+	t.Run("400 with valid Scrive envelope surfaces typed error", func(t *testing.T) {
+		cli, _ := stubScrive(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{
+				"error_type":    "request_parameters_invalid",
+				"error_message": "The 'file' parameter is missing.",
+				"http_code":     400
+			}`))
+		})
+
+		doc, se := cli.NewDocument(NewDocumentParams{})
+		if doc.ID != nil {
+			t.Errorf("expected nil ID, got %v", *doc.ID)
+		}
+		if se == nil {
+			t.Fatal("expected non-nil ScriveError")
+		}
+		if se.HttpCode != 400 {
+			t.Errorf("expected HttpCode 400, got %d", se.HttpCode)
+		}
+		if se.ErrorType != "request_parameters_invalid" {
+			t.Errorf("expected typed envelope, got %q", se.ErrorType)
+		}
+	})
+
+	t.Run("401 plain text surfaces unparseable_response with real status", func(t *testing.T) {
+		// Regression: end-to-end check that the plain-text 401 from
+		// Scrive's auth layer (the production failure mode that motivated
+		// the unparseableResponseError fallback) bubbles up cleanly.
+		cli, _ := stubScrive(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("No valid access credentials were provided. Please refer to our API documentation."))
+		})
+
+		_, se := cli.NewDocument(NewDocumentParams{})
+		if se == nil {
+			t.Fatal("expected non-nil ScriveError")
+		}
+		if se.HttpCode != http.StatusUnauthorized {
+			t.Errorf("expected HttpCode 401, got %d", se.HttpCode)
+		}
+		if se.ErrorType != ErrorTypeUnparseableResponse {
+			t.Errorf("expected ErrorType %q, got %q", ErrorTypeUnparseableResponse, se.ErrorType)
+		}
+		if !strings.Contains(se.ErrorMessage, "No valid access credentials") {
+			t.Errorf("expected body in ErrorMessage, got %q", se.ErrorMessage)
+		}
+	})
+
+	t.Run("502 HTML surfaces unparseable_response with real status", func(t *testing.T) {
+		cli, _ := stubScrive(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("<html><body>502 Bad Gateway</body></html>"))
+		})
+
+		_, se := cli.NewDocument(NewDocumentParams{})
+		if se == nil {
+			t.Fatal("expected non-nil ScriveError")
+		}
+		if se.HttpCode != http.StatusBadGateway {
+			t.Errorf("expected HttpCode 502, got %d", se.HttpCode)
+		}
+		if se.ErrorType != ErrorTypeUnparseableResponse {
+			t.Errorf("expected ErrorType %q, got %q", ErrorTypeUnparseableResponse, se.ErrorType)
+		}
+	})
+}
+
+func TestClient_UpdateDocument_Success(t *testing.T) {
+	var (
+		captured []recordedRequest
+		mu       sync.Mutex
+	)
+	cli, _ := stubScrive(t, recordingHandler(&captured, &mu, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"doc-123","status":"preparation"}`))
+	}))
+
+	id := "doc-123"
+	doc := &Document{ID: &id, Title: String("My Contract")}
+	got, se := cli.UpdateDocument(UpdateDocumentParams{
+		DocumentID: "doc-123",
+		Document:   doc,
+	})
+	if se != nil {
+		t.Fatalf("expected nil ScriveError, got %+v", se)
+	}
+	if got.ID == nil || *got.ID != "doc-123" {
+		t.Fatalf("expected ID doc-123, got %v", got.ID)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(captured))
+	}
+	rec := captured[0]
+	if rec.Path != "/api/v2/documents/doc-123/update" {
+		t.Errorf("expected path /api/v2/documents/doc-123/update, got %s", rec.Path)
+	}
+	// The document JSON is sent as a multipart form field. We don't roundtrip
+	// the entire Document struct here; the contract is just that the title
+	// we set ends up on the wire.
+	if !strings.Contains(string(rec.Body), "My Contract") {
+		t.Errorf("expected document JSON to include title, got %s", rec.Body)
+	}
+}
+
+func TestClient_composeURL(t *testing.T) {
+	mkClient := func(root string) *Client {
+		c, err := NewClient(Config{
+			APIRoot: &root,
+			PAC:     &PAC{ClientCredentialsIdentifier: "x"},
+		})
+		if err != nil {
+			t.Fatalf("NewClient: %v", err)
+		}
+		return c
+	}
+
+	t.Run("bare hostname implies https", func(t *testing.T) {
+		c := mkClient("api-scrive.com")
+		got := c.composeURL("documents/new")
+		want := "https://api-scrive.com/api/v2/documents/new"
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("explicit http scheme is honored", func(t *testing.T) {
+		c := mkClient("http://localhost:1234")
+		got := c.composeURL("documents/new")
+		want := "http://localhost:1234/api/v2/documents/new"
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("explicit https scheme is honored", func(t *testing.T) {
+		c := mkClient("https://api-scrive.com")
+		got := c.composeURL("documents/new")
+		want := "https://api-scrive.com/api/v2/documents/new"
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("trailing slash on APIRoot is stripped", func(t *testing.T) {
+		c := mkClient("http://localhost:1234/")
+		got := c.composeURL("documents/new")
+		want := "http://localhost:1234/api/v2/documents/new"
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+}

--- a/common_test.go
+++ b/common_test.go
@@ -15,9 +15,10 @@ var envOnce sync.Once
 
 func readEnv() {
 	envOnce.Do(func() {
-		if err := godotenv.Load(); err != nil {
-			panic(err)
-		}
+		// .env is optional — fall back to the actual process environment
+		// (set by CI secrets, the developer's shell, etc.) when the file
+		// isn't present.
+		_ = godotenv.Load()
 	})
 }
 
@@ -34,7 +35,21 @@ func getConfig() (scrive.Config, error) {
 	return config, nil
 }
 
-func getClient() *scrive.Client {
+// hasScriveCredentials returns true when all four PAC env vars are set, so the
+// integration tests have something to authenticate with.
+func hasScriveCredentials() bool {
+	readEnv()
+	return os.Getenv("CLIENT_CREDENTIALS_IDENTIFIER") != "" &&
+		os.Getenv("CLIENT_CREDENTIALS_SECRET") != "" &&
+		os.Getenv("TOKEN_CREDENTIALS_IDENTIFIER") != "" &&
+		os.Getenv("TOKEN_CREDENTIALS_SECRET") != ""
+}
+
+func getClient(t *testing.T) *scrive.Client {
+	t.Helper()
+	if !hasScriveCredentials() {
+		t.Skip("Scrive PAC credentials are not configured; set CLIENT_CREDENTIALS_IDENTIFIER/SECRET and TOKEN_CREDENTIALS_IDENTIFIER/SECRET to run integration tests")
+	}
 	config, err := getConfig()
 	if err != nil {
 		panic(err)

--- a/errors_test.go
+++ b/errors_test.go
@@ -52,3 +52,131 @@ func TestUnparseableResponseError(t *testing.T) {
 		}
 	})
 }
+
+// TestClient_expect covers the four code paths through Client.expect, the
+// function that routes between localError, parseResponseError, and
+// unparseableResponseError. Same-package test so we can call the unexported
+// method directly.
+func TestClient_expect(t *testing.T) {
+	c := &Client{}
+
+	t.Run("success: returns nil when code matches and out is decoded", func(t *testing.T) {
+		var out struct {
+			Hello string `json:"hello"`
+		}
+		se := c.expect(200, []byte(`{"hello":"world"}`), 200, &out, false)
+		if se != nil {
+			t.Fatalf("expected nil ScriveError, got %+v", se)
+		}
+		if out.Hello != "world" {
+			t.Fatalf("expected out.Hello=\"world\", got %q", out.Hello)
+		}
+	})
+
+	t.Run("success with bin=true skips JSON parsing", func(t *testing.T) {
+		se := c.expect(200, []byte("not json at all"), 200, nil, true)
+		if se != nil {
+			t.Fatalf("expected nil ScriveError for bin=true success, got %+v", se)
+		}
+	})
+
+	t.Run("success but body fails to parse returns localError", func(t *testing.T) {
+		var out struct {
+			Hello string `json:"hello"`
+		}
+		se := c.expect(200, []byte("not json"), 200, &out, false)
+		if se == nil {
+			t.Fatal("expected non-nil ScriveError when success body fails to parse")
+		}
+		if se.ErrorType != ErrorTypeLocal {
+			t.Fatalf("expected ErrorType %q, got %q", ErrorTypeLocal, se.ErrorType)
+		}
+		if se.HttpCode != -1 {
+			t.Fatalf("expected HttpCode -1 for local parse failure, got %d", se.HttpCode)
+		}
+	})
+
+	t.Run("error: parses well-formed Scrive error envelope", func(t *testing.T) {
+		body := []byte(`{
+			"error_type":    "request_parameters_invalid",
+			"error_message": "The 'document' parameter is missing.",
+			"http_code":     400
+		}`)
+		se := c.expect(400, body, 200, nil, false)
+		if se == nil {
+			t.Fatal("expected non-nil ScriveError for non-success status")
+		}
+		if se.HttpCode != 400 {
+			t.Fatalf("expected HttpCode 400, got %d", se.HttpCode)
+		}
+		if se.ErrorType != "request_parameters_invalid" {
+			t.Fatalf("expected ErrorType from JSON envelope, got %q", se.ErrorType)
+		}
+		if !strings.Contains(se.ErrorMessage, "missing") {
+			t.Fatalf("expected envelope error message, got %q", se.ErrorMessage)
+		}
+	})
+
+	t.Run("error with non-JSON body surfaces unparseable_response with real status", func(t *testing.T) {
+		// Regression test for the previous behavior: when Scrive returned a
+		// non-JSON 401 (e.g. plain-text "No valid access credentials..."),
+		// expect() would localError() the JSON parse failure and drop the
+		// HTTP status. Now it must surface httpCode + body.
+		body := []byte("No valid access credentials were provided. Please refer to our API documentation.")
+		se := c.expect(401, body, 200, nil, false)
+		if se == nil {
+			t.Fatal("expected non-nil ScriveError for non-JSON error body")
+		}
+		if se.HttpCode != 401 {
+			t.Fatalf("expected real HttpCode 401, got %d", se.HttpCode)
+		}
+		if se.ErrorType != ErrorTypeUnparseableResponse {
+			t.Fatalf("expected ErrorType %q, got %q", ErrorTypeUnparseableResponse, se.ErrorType)
+		}
+		if !strings.Contains(se.ErrorMessage, "No valid access credentials") {
+			t.Fatalf("expected body in ErrorMessage, got %q", se.ErrorMessage)
+		}
+	})
+
+	t.Run("error with HTML body still surfaces unparseable_response", func(t *testing.T) {
+		body := []byte("<html><body>502 Bad Gateway</body></html>")
+		se := c.expect(502, body, 200, nil, false)
+		if se == nil {
+			t.Fatal("expected non-nil ScriveError")
+		}
+		if se.HttpCode != 502 {
+			t.Fatalf("expected HttpCode 502, got %d", se.HttpCode)
+		}
+		if se.ErrorType != ErrorTypeUnparseableResponse {
+			t.Fatalf("expected ErrorType %q, got %q", ErrorTypeUnparseableResponse, se.ErrorType)
+		}
+	})
+
+	t.Run("error with valid JSON but missing required envelope fields surfaces unparseable_response", func(t *testing.T) {
+		// parseResponseError requires error_type, error_message, and http_code
+		// to all be present. A JSON body that's syntactically valid but missing
+		// any of those should fall back to unparseable_response so the real
+		// HTTP status survives.
+		body := []byte(`{"some_other_shape": "value"}`)
+		se := c.expect(403, body, 200, nil, false)
+		if se == nil {
+			t.Fatal("expected non-nil ScriveError")
+		}
+		if se.HttpCode != 403 {
+			t.Fatalf("expected HttpCode 403, got %d", se.HttpCode)
+		}
+		if se.ErrorType != ErrorTypeUnparseableResponse {
+			t.Fatalf("expected ErrorType %q, got %q", ErrorTypeUnparseableResponse, se.ErrorType)
+		}
+	})
+
+	t.Run("ScriveErrorToError formats unparseable_response usefully", func(t *testing.T) {
+		body := []byte("No valid access credentials were provided.")
+		se := c.expect(401, body, 200, nil, false)
+		err := ScriveErrorToError(se)
+		msg := err.Error()
+		if !strings.Contains(msg, "401") || !strings.Contains(msg, "unparseable_response") || !strings.Contains(msg, "No valid access credentials") {
+			t.Fatalf("expected formatted error to include status/type/body, got %q", msg)
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,15 @@
 module github.com/Preciselyco/goscrive
 
-go 1.13
+go 1.21
 
 require (
 	github.com/joho/godotenv v1.5.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/prepare_test.go
+++ b/prepare_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestNewDocument(t *testing.T) {
-	cli := getClient()
+	cli := getClient(t)
 	doc, se := cli.NewDocument(scrive.NewDocumentParams{})
 	failIfScriveE(t, "TestPrepare: cli.NewDocument", se)
 	log("got document response: %s", marshalIndentFail(t, "TestNewDocument: document response", doc))
 }
 
 func TestNewDocumentWithDoc(t *testing.T) {
-	cli := getClient()
+	cli := getClient(t)
 	documentBody, err := ioutil.ReadFile("testdata/document.pdf")
 	failIfE(t, "TestNewDocumentWithDoc: readFile", err)
 	saved := true
@@ -31,7 +31,7 @@ func TestNewDocumentWithDoc(t *testing.T) {
 }
 
 func TestNewDocumentFromTemplate(t *testing.T) {
-	cli := getClient()
+	cli := getClient(t)
 	documentID := os.Getenv("TEST_TEMPLATE_ID")
 	doc, se := cli.NewDocumentFromTemplate(scrive.NewDocumentFromTemplateParams{
 		DocumentID: documentID,
@@ -41,7 +41,7 @@ func TestNewDocumentFromTemplate(t *testing.T) {
 }
 
 func TestDocumentClone(t *testing.T) {
-	cli := getClient()
+	cli := getClient(t)
 	documentID := os.Getenv("TEST_TEMPLATE_ID")
 	doc, se := cli.CloneDocument(scrive.CloneDocumentParams{
 		DocumentID: documentID,
@@ -51,7 +51,7 @@ func TestDocumentClone(t *testing.T) {
 }
 
 func TestDocumentUpdate(t *testing.T) {
-	cli := getClient()
+	cli := getClient(t)
 	documentID := os.Getenv("TEST_TEMPLATE_ID")
 	newTitle := "some nice new title"
 	doc, se := cli.UpdateDocument(scrive.UpdateDocumentParams{
@@ -66,7 +66,7 @@ func TestDocumentUpdate(t *testing.T) {
 }
 
 func TestSetAttachments(t *testing.T) {
-	cli := getClient()
+	cli := getClient(t)
 	documentID := os.Getenv("TEST_TEMPLATE_ID")
 	attachment, err := ioutil.ReadFile("testdata/document.pdf")
 	failIfE(t, "readFile", err)


### PR DESCRIPTION
## Summary
Adds test coverage and the small Config surface needed to test the request-construction path without live Scrive credentials.

### Coverage added

**Unit tests for `Client.expect`** — locks in the routing between `localError`, `parseResponseError`, and `unparseableResponseError`:
- Success: code matches, body decodes → nil ScriveError.
- Success: `bin=true` skips JSON parsing.
- Success: body fails to parse → `localError` with `HttpCode: -1`.
- Non-success: well-formed Scrive envelope → returned verbatim.
- Non-success: plain text body (regression for the 401 \"No valid access credentials…\" case) → `unparseable_response` with the real status code.
- Non-success: HTML body → `unparseable_response` with the real status.
- Non-success: JSON without envelope fields → `unparseable_response`.
- `ScriveErrorToError` formats `unparseable_response` with status, type, and body.

**End-to-end tests against an `httptest.Server`** — `client_http_test.go`:
- `NewDocument` success: asserts on POST path, multipart Content-Type, file name + bytes in the body, and JSON decoding of the 201 response.
- `NewDocument` 400 with envelope → typed ScriveError.
- `NewDocument` 401 plain text → `unparseable_response` with real status.
- `NewDocument` 502 HTML → `unparseable_response` with real status.
- `UpdateDocument` success: asserts on POST path (`/api/v2/documents/{id}/update`) and that the document JSON ends up on the wire.
- `composeURL`: bare hostname, explicit `http://`, explicit `https://`, trailing-slash handling.

### Config additions (backward compatible)

- `Config.HTTPClient` — optional `*http.Client` override; nil keeps the current default (30s timeout, custom Dialer).
- `composeURL` honors a scheme on `Config.APIRoot` when present (`http://localhost:1234`); bare hostnames still default to `https://`.

### CI

Adds `.github/workflows/test.yml` running `go vet`, `go build`, and `go test -race` on every PR and push to master. Integration tests in `prepare_test.go` (which require Scrive PAC env vars) now self-skip when those vars are unset, so the workflow runs cleanly without secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)